### PR TITLE
Added filtering support using isNull and isNotNull

### DIFF
--- a/src/Query/Filter.php
+++ b/src/Query/Filter.php
@@ -280,7 +280,9 @@ class Filter
             $this->qb->setParameter($fieldName2, $value[1]);
         } else {
             $this->qb->$whereCondition($this->qb->expr()->$condition($alias . '.' . $field, ':' . $fieldName1));
-            $this->qb->setParameter($fieldName1, $value);
+            if (!in_array($condition, ['isNull', 'isNotNull'])) {
+                $this->qb->setParameter($fieldName1, $value);
+            }
         }
 
     }


### PR DESCRIPTION
Simple fix for the operation of filter parameters with isNull and isNotNull.
Now you can do something like this:
?filter[status][isNull]=status (or some string | empty value)
or
?filter[status][isNotNull]=status (or some string | empty value)